### PR TITLE
Fixed issue with Series_Epiodes

### DIFF
--- a/tvdbsimple/series.py
+++ b/tvdbsimple/series.py
@@ -132,7 +132,10 @@ class Series_Episodes(TVDB):
         """
         super(Series_Episodes, self).__init__(id)
         self._set_language(language)
+        self._FILTERS = {}
         self.update_filters(**kwargs)
+        self._PAGES = -1
+        self._PAGES_LIST = {}
 
     def update_filters(self, **kwargs):
         """


### PR DESCRIPTION
After the first use on Series_Epiodes and more inits of that class will not have any results because Series_Epiodes._PAGES_LIST variavble is not re initilaised (my guess is something to do with how python deals with where and how variables are stored in memory and when they are destroyed).
I added the resetting of Series_Epiodes._PAGES and Series_Epiodes._FILTERS as well as I thought the same issue might happen with them.
Please either accept this pull request or fix the issue your way.