### PR TITLE
basic bug fixes without breaking backwards compatibility

### DIFF
--- a/tvdbsimple/base.py
+++ b/tvdbsimple/base.py
@@ -116,7 +116,7 @@ class TVDB(object):
             else:
                 error = "Unknown error while authenticating. Check your api key or your user/userkey"
                 try:
-                    error = response.json()['error']
+                    error = response.json()['Error']
                 except:
                     pass
                 raise AuthenticationError(error)
@@ -141,7 +141,7 @@ class TVDB(object):
         elif not forceNewToken:
             return self._request(method=method, path=path, params=params, payload=payload, forceNewToken=True)
         try:
-            raise Exception(response.json()['error'])
+            raise Exception(response.json()['Error'])
         except:
             response.raise_for_status()
 

--- a/tvdbsimple/search.py
+++ b/tvdbsimple/search.py
@@ -16,7 +16,7 @@ class Search(TVDB):
     _BASE_PATH = 'search'
     _URLS = {
         'series': '/series',
-        'seriesparams': '/series/params'
+        'series_params': '/series/params'
     }
 
     def series(self, name='', imdbId='', zap2itId='', language=''):

--- a/tvdbsimple/series.py
+++ b/tvdbsimple/series.py
@@ -106,6 +106,9 @@ class Series_Episodes(TVDB):
         'query': '/{id}/episodes/query',
         'query_params': '/{id}/episodes/query/params'
     }
+    _PAGES = -1
+    _PAGES_LIST = {}
+    _FILTERS = {}
 
     def __init__(self, id, language='', **kwargs):
         """
@@ -130,10 +133,6 @@ class Series_Episodes(TVDB):
         super(Series_Episodes, self).__init__(id)
         self._set_language(language)
         self.update_filters(**kwargs)
-
-        self._PAGES = -1
-        self._PAGES_LIST = {}
-        self._FILTERS = {}
 
     def update_filters(self, **kwargs):
         """

--- a/tvdbsimple/series.py
+++ b/tvdbsimple/series.py
@@ -104,11 +104,8 @@ class Series_Episodes(TVDB):
         'summary': '/{id}/episodes/summary',
         'episodes': '/{id}/episodes',
         'query': '/{id}/episodes/query',
-        'queryparams': '/{id}/episodes/query/params'
+        'query_params': '/{id}/episodes/query/params'
     }
-    _PAGES = -1
-    _PAGES_LIST = {}
-    _FILTERS = {}
 
     def __init__(self, id, language='', **kwargs):
         """
@@ -133,6 +130,10 @@ class Series_Episodes(TVDB):
         super(Series_Episodes, self).__init__(id)
         self._set_language(language)
         self.update_filters(**kwargs)
+
+        self._PAGES = -1
+        self._PAGES_LIST = {}
+        self._FILTERS = {}
 
     def update_filters(self, **kwargs):
         """
@@ -264,7 +265,7 @@ class Series_Images(TVDB):
     _URLS = {
         'imagequery': '/{id}/images/query',
         'summary': '/{id}/images',
-        'queryparams': '/{id}/images/query/params'
+        'query_params': '/{id}/images/query/params'
     }
     _FILTERS = {}
 
@@ -318,7 +319,7 @@ class Series_Images(TVDB):
         path = self._get_id_path('summary')
         
         response = self._GET(path)
-        self._set_attrs_to_values(response)
+        # self._set_attrs_to_values(response)
         return response
 
     def query_params(self):

--- a/tvdbsimple/updates.py
+++ b/tvdbsimple/updates.py
@@ -17,7 +17,7 @@ class Updates(TVDB):
     _BASE_PATH = 'updated'
     _URLS = {
         'query': '/query',
-        'params': '/query/params'
+        'update_params': '/query/params'
     }
     _FILTERS = {}
 

--- a/tvdbsimple/user.py
+++ b/tvdbsimple/user.py
@@ -147,9 +147,6 @@ class User_Ratings(TVDB):
         'add': '/{itemType}/{itemId}/{itemRating}',
         'delete': '/{itemType}/{itemId}'
     }
-    _PAGES = -1
-    _PAGES_LIST = {}
-    _FILTERS = {}
 
     def __init__(self, user, key, **kwargs):
         """
@@ -164,6 +161,10 @@ class User_Ratings(TVDB):
         super(User_Ratings, self).__init__(user=user, key=key)
         self._FILTERS = {}
         self.update_filters(**kwargs)
+
+        self._PAGES = -1
+        self._PAGES_LIST = {}
+        self._FILTERS = {}
 
     def update_filters(self, **kwargs):
         """

--- a/tvdbsimple/user.py
+++ b/tvdbsimple/user.py
@@ -147,6 +147,9 @@ class User_Ratings(TVDB):
         'add': '/{itemType}/{itemId}/{itemRating}',
         'delete': '/{itemType}/{itemId}'
     }
+    _PAGES = -1
+    _PAGES_LIST = {}
+    _FILTERS = {}
 
     def __init__(self, user, key, **kwargs):
         """
@@ -161,10 +164,6 @@ class User_Ratings(TVDB):
         super(User_Ratings, self).__init__(user=user, key=key)
         self._FILTERS = {}
         self.update_filters(**kwargs)
-
-        self._PAGES = -1
-        self._PAGES_LIST = {}
-        self._FILTERS = {}
 
     def update_filters(self, **kwargs):
         """


### PR DESCRIPTION
basic bug fixes without breaking backwards compatibility (except for Series_Images.summary() not settings attrs anymore...)

series.py
  Series_Episodes:
  - fixed _URLS{'queryparams'} to _URLS{'query_params'} so Series_Episodes.query_params() actually works
  - converted _PAGES, _PAGES_LIST, and _FILTERS from class members to instance members so calls to Series_Episodes works more than once
  Series_Images
  - fixed _URLS{'queryparams'} to _URLS{'query_params'} so Series_Images.query_params() actually works
  - stop settings attrs in summary

updates.py
  Updates:
  - fixed _URLS{'params'} init to _URLS{'update_params'} so Updates.update_params() actually works

search.py
  Search
  - fixed _URLS{'seriesparams'} to _URLS{'series_params'} so Search.series_params() actually works

user.py
  User_Ratings
  - converted _PAGES, _PAGES_LIST, and _FILTERS from class members to instance members so calls to User_Ratings works more than once

base.py
  TVDB
  - fixed 'error' key in to the JSON returned in the event of get_token or _request fail